### PR TITLE
Store array of only odd numbers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn num_primes(num: u64, show_primes: bool) -> u32 {
 	let root = isqrt(num);
 	let mut i:usize = 3;
 	while i < (root + 1) as usize { // only check to the square
-		if is_prime[i / 16] >> ((i/2) % 16) & 1 == 1 { // checks if bit of current number (i) is high
+		if is_prime[i / 16] >> ((i/2) % 8) & 1 == 1 { // checks if bit of current number (i) is high
 			let mut k: usize = i;
 			while k * i <= num as usize { // only check to number
 				is_prime[(i * k) / 16] &= !(1u8 << (((i * k)/2) % 8) as u8); // sets bit to low using AND NOT

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,8 @@ use std::env;
 fn main() {
 	// takes user imput and puts it in a vector
 	let input: Vec<String> = env::args().collect();
-	// takes first element in input vector and converts it to a u32 for prime number program
-	let num: u32 = input[1].parse::<u32>().unwrap();
+	// takes first element in input vector and converts it to a u64 for prime number program
+	let num: u64 = input[1].parse::<u64>().unwrap();
 	// defaults to NOT showing all primes, and only counting them
 	let list_primes = if input.len() > 2 { // checks if there are any more args
 		match input[2].as_ref() {	// if the args match, show all primes
@@ -53,7 +53,7 @@ fn main() {
 	println!("\n{} primes", num_primes(num, list_primes));
 }
 
-fn num_primes(num: u32, show_primes: bool) -> u32 {
+fn num_primes(num: u64, show_primes: bool) -> u32 {
 	let mut count: u32 = 0;
 	let elements = if num % 16 == 0 { num / 16 } else { num / 16 + 1 };
 
@@ -66,7 +66,6 @@ fn num_primes(num: u32, show_primes: bool) -> u32 {
 	let root = isqrt(num);
 	let mut i:usize = 3;
 	while i < (root + 1) as usize { // only check to the square
-		if i % 2 == 0 { continue; }
 		if is_prime[i / 16] >> ((i/2) % 16) & 1 == 1 { // checks if bit of current number (i) is high
 			let mut k: usize = i;
 			while k * i <= num as usize { // only check to number
@@ -80,8 +79,7 @@ fn num_primes(num: u32, show_primes: bool) -> u32 {
 	// remove ones above given number (sets bits to low so they are ignored when counting)
 	let mut i = num + 1;
 	while i < elements * 16 { // only worry about values greater than input num
-		if i % 2 == 0 { continue; }
-		is_prime[(elements - 1) as usize] &= !(2u8.pow(i/2 % 8) as u8); // sets bit to low using AND NOT (see above)
+		is_prime[(elements - 1) as usize] &= !(1u8<<(i/2 % 8) as u8); // sets bit to low using AND NOT (see above)
 		i += 2;
 	}
 
@@ -112,7 +110,7 @@ fn num_primes(num: u32, show_primes: bool) -> u32 {
 
 
 // recursive integer square root function found on Wikipedia
-fn isqrt(n: u32) -> u32 {
+fn isqrt(n: u64) -> u64 {
 	if n < 2 {
 		return n;
 	} else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,7 @@
 	translation of python code from
 	https://www.quora.com/How-many-prime-numbers-are-there-between-1-and-1000/answers/15501891
 	with optimizations:
-		marks all evens (except 2) as not prime (false)
-		skips ALL evens when multiplying
+		skips ALL evens
 */
 
 /*
@@ -56,45 +55,44 @@ fn main() {
 
 fn num_primes(num: u32, show_primes: bool) -> u32 {
 	let mut count: u32 = 0;
-	let elements = if num % 8 == 0 { num / 8 } else { num / 8 + 1 };
+	let elements = if num % 16 == 0 { num / 16 } else { num / 16 + 1 };
 
 	// create new "data type" to fix bool=byte storage issue (reduce mem usage by 8)
 	let mut is_prime = vec![0b11111111; elements as usize]; // assigns 1's to every digit
-	// makes all evens NOT prime
-	for e in 0..elements as usize {
-		let mut index = 0; // keeps track of place value
-		while index <= 8 { // using while to count by 2's (why, Rust, why?)
-			is_prime[e] &= !(2u8.pow(index) as u8); // &'s input with inverse of 2^(digit place)
-			index += 2;
-		}
-	}
-	is_prime[0] |= 1u8 << 2; // OR'ing sets bit to high (00110010 OR 00000001 = 00110011)
-	is_prime[0] &= !3u8; // AND NOT'ing sets bit to low (00110010 AND !00000010 = 00110000)
+
+	is_prime[0] = 0b11111110; // mark 1 as not prime
 
 	// checks all odds up to the square
 	let root = isqrt(num);
-	for i in 3..(root + 1) as usize { // only check to the square
-		if is_prime[i / 8] >> (i % 8) & 1 == 1 { // checks if bit of current number (i) is high
+	let mut i:usize = 3;
+	while i < (root + 1) as usize { // only check to the square
+		if i % 2 == 0 { continue; }
+		if is_prime[i / 16] >> ((i/2) % 16) & 1 == 1 { // checks if bit of current number (i) is high
 			let mut k: usize = i;
-			while k * i <= num as usize { // only check to 
-				is_prime[(i * k) / 8] &= !(1u8 << ((i * k) % 8) as u8); // sets bit to low using AND NOT (see above)
+			while k * i <= num as usize { // only check to number
+				is_prime[(i * k) / 16] &= !(1u8 << (((i * k)/2) % 8) as u8); // sets bit to low using AND NOT
 				k += 2;
 			}
 		}
+		i += 2;
 	}
 
 	// remove ones above given number (sets bits to low so they are ignored when counting)
-	for i in (num + 1)..elements * 8 { // only worry about values greater than input num
-		is_prime[(elements - 1) as usize] &= !(2u8.pow(i % 8) as u8); // // sets bit to low using AND NOT (see above)
+	let mut i = num + 1;
+	while i < elements * 16 { // only worry about values greater than input num
+		if i % 2 == 0 { continue; }
+		is_prime[(elements - 1) as usize] &= !(2u8.pow(i/2 % 8) as u8); // sets bit to low using AND NOT (see above)
+		i += 2;
 	}
 
 	// counts the primes
 	if show_primes { // prints out all primes (very slow and may crash terminal)
+		if num > 2 { print!("2, "); }
 		for i in 0..is_prime.len() { // goes through every number
 			for e in 0..8 { // goes through every bit in number
 				if (is_prime[i as usize] >> e) & 1u8 == 1 { // if bit is high
 					count += 1; // increase prime count
-					print!("{}, ", i * 8 + e); // print out the number
+					print!("{}, ", i * 16 + e * 2 + 1); // print out the number
 				}
 			}
 		}
@@ -104,6 +102,11 @@ fn num_primes(num: u32, show_primes: bool) -> u32 {
 			count += e.count_ones(); // function counts all 1's in the number
 		}
 	}
+
+	if num > 2 {
+		count += 1;
+	}
+
 	return count;
 }
 


### PR DESCRIPTION
Rather than storing an array of all integers from 0 to n, this cuts the array size in half by only storing an array of all odd integers from 1 to n. This change improves performance with large numbers and makes it more reasonable (RAM-wise) to count the primes of larger numbers.